### PR TITLE
feat(django): add /auth/status/, an auth state endpoint

### DIFF
--- a/api/test/users.py
+++ b/api/test/users.py
@@ -1,0 +1,29 @@
+from http import HTTPStatus
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+
+class AuthTest(TestCase):
+    """Test user authentication and authentication state"""
+
+    def setUp(self) -> None:
+        # Construct an HTTP client
+        self.client = APIClient()
+
+        # Create a test user
+        self.user = User.objects.create_user(
+            username="test", password="test_password"
+        )
+
+    def test_status_unauthorized(self) -> None:
+        """Test that /auth/status/ while unauthed returns UNAUTHORIZED"""
+        response = self.client.get("/auth/status/")
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_status(self) -> None:
+        """Test that /auth/status/ while authed returns OK"""
+        self.client.force_authenticate(self.user)
+        response = self.client.get("/auth/status/")
+        self.assertEqual(response.status_code, HTTPStatus.OK)

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,1 +1,2 @@
 from .test.posts import PostsTest  # noqa: F401
+from .test.users import AuthTest  # noqa: F401

--- a/api/urls.py
+++ b/api/urls.py
@@ -9,5 +9,6 @@ router.register(r"posts", views.Posts)
 
 urlpatterns = [
     path("", include(router.urls)),
+    path("auth/status/", views.Status.as_view()),
     path("auth/", include("rest_framework.urls")),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -4,12 +4,21 @@ from django.contrib.auth.models import User
 from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from rest_framework.authentication import BasicAuthentication
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 
 from .middleware import CsrfExemptSessionAuthentication
 from .models import Post
 from .serializers import PostSerializer, UserSerializer
+
+
+class Status(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: HttpRequest) -> Response:
+        return Response(status=HTTPStatus.OK)
 
 
 class Users(ModelViewSet):


### PR DESCRIPTION
This can be used to check a session's state at any given time. If the session has gone stale, or there is no session, `HTTP UNAUTHORIZED` is returned. Otherwise, an `HTTP OK` is returned.

Signed-off-by: Kevin Morris <kevr@0cost.org>