### PR TITLE
feat(frontend): provide `next` search param to <Login>

### DIFF
--- a/frontend/src/AuthWidget.js
+++ b/frontend/src/AuthWidget.js
@@ -1,12 +1,13 @@
 import { useEffect, useRef } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { apiStatus } from "./API";
 
 const AuthWidget = () => {
   const session = useSelector((state) => state.session);
   const dispatch = useDispatch();
   const apiLock = useRef(false);
+  const location = useLocation();
 
   useEffect(() => {
     // Renders can be called more than once, since React expects
@@ -49,10 +50,11 @@ const AuthWidget = () => {
     });
   };
 
+  const pathname = encodeURIComponent(location.pathname);
   const content = !session ? (
     <div className="centered">
       <Link
-        to="/login/"
+        to={`/login/?next=${pathname}`}
         className="waves-effect waves-light red lighten-1 btn"
       >
         Login

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -1,6 +1,6 @@
 import { useDispatch } from "react-redux";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { apiLogin } from "../API";
 
 const Login = () => {
@@ -11,6 +11,9 @@ const Login = () => {
 
   const dispatch = useDispatch();
   const navigate = useNavigate();
+
+  const [params] = useSearchParams();
+  const next = decodeURIComponent(params.get("next", "/"));
 
   useEffect(() => {
     dispatch({ type: "SET_TITLE", title: "Login" });
@@ -28,7 +31,7 @@ const Login = () => {
           username: user,
         }),
       });
-      navigate("/");
+      navigate(next);
     } else {
       setDone(true);
       setError("Invalid username or password");


### PR DESCRIPTION
Allows us to login, then return to the page we were on when clicking the Login button.

Signed-off-by: Kevin Morris <kevr@0cost.org>