### PR TITLE
feat(frontend): populate banner text with author + restyle banner

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -93,6 +93,10 @@
   height: 100%;
 }
 
+.full-width {
+  width: 100%;
+}
+
 .flex {
   flex: 1 1 auto;
 }
@@ -123,13 +127,36 @@
 
 .banner {
   background-image: url("../public/images/banner.jpg");
-  background-size: cover;
+  background-size: 100%;
+  background-position: 50% 50%;
   height: 200px;
-  margin-bottom: 1rem;
+}
+
+.banner-container {
+  background: linear-gradient(90deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.65) 50%, rgba(0, 0, 0, 0) 100%);
+  height: 100%;
+  width: 100%;
 }
 
 .banner-text {
-  margin: 0;
+  text-shadow: 2px 2px 4px black;
+  margin: 0px;
+}
+
+.banner .text-container {
+  text-align: right;
+}
+
+.banner .annotation {
+  font-size: 18px;
+}
+
+.shadowed {
+  text-shadow: 2px 2px 4px black;
+}
+
+*[data-testid="edit-button"] {
+    margin-top: 15px;
 }
 
 .card small {

--- a/frontend/src/Layout.js
+++ b/frontend/src/Layout.js
@@ -8,7 +8,8 @@ import config from "./config.json";
 
 const Layout = ({ children }) => {
   const session = useSelector((state) => state.session);
-  const title = useSelector((state) => state.title);
+  const title = useSelector((state) => state.title.page);
+  const author = useSelector((state) => state.title.author);
   const dispatch = useDispatch();
 
   let titleDisplay = config.appTitle;
@@ -28,27 +29,43 @@ const Layout = ({ children }) => {
         <title>{titleDisplay}</title>
       </Helmet>
 
-      <div className="sidebar">
-        <Link to="/">
-          <div className="centered">
-            <img src={"/favicon.ico"} className="app-logo" alt="logo" />
-          </div>
-        </Link>
-      </div>
-      <div className="content">
-        <div>
-          <div className="banner flex-display flex-col">
+      <div className="full-width">
+        <div className="banner flex-display flex-col">
+          <div className="banner-container flex flex-display flex-col">
             <div className="flex"></div>
-            <h3 className="banner-text" data-testid="page-title">
-              {title}
-            </h3>
+            <div className="flex-display flex-row">
+              <div className="flex"></div>
+              <div className="text-container">
+                <h3 className="banner-text" data-testid="page-title">
+                  {title}
+                </h3>
+                {author && (
+                  <small className="author">
+                    by <Link to={`/users/${author.id}`}>{author.name}</Link>
+                  </small>
+                )}
+              </div>
+              <div className="flex"></div>
+            </div>
+
             <div className="flex"></div>
           </div>
         </div>
-        <div>{children}</div>
-      </div>
-      <div className="sidebar">
-        <AuthWidget />
+        <div className="full-width flex-display flex-row">
+          <div className="sidebar">
+            <Link to="/">
+              <div className="centered">
+                <img src={"/favicon.ico"} className="app-logo" alt="logo" />
+              </div>
+            </Link>
+          </div>
+          <div className="content">
+            <div>{children}</div>
+          </div>
+          <div className="sidebar">
+            <AuthWidget />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/Post.js
+++ b/frontend/src/pages/Post.js
@@ -26,7 +26,11 @@ const Post = () => {
     apiRequest(session, dispatch, `/posts/${id}`)
       .then((response) => response.json())
       .then((data) => {
-        dispatch({ type: "SET_TITLE", title: data.title });
+        dispatch({
+          type: "SET_TITLE",
+          title: data.title,
+          author: data.author,
+        });
         setPost(data);
         setLoading(false);
       })
@@ -49,13 +53,10 @@ const Post = () => {
   return (
     <div>
       <div className="post-author text-small">
-        by{" "}
-        <Link to={`/users/${post.author.id}`} data-testid="post-author">
-          {post.author.name}
-        </Link>
         {isOwner && (
           <Link
             className="red lighten-1 btn abs-right"
+            data-testid="edit-button"
             to={`/posts/${id}/edit`}
           >
             {"Edit Post"}

--- a/frontend/src/pages/Post.test.js
+++ b/frontend/src/pages/Post.test.js
@@ -51,11 +51,6 @@ test("Post renders", async () => {
   }
 
   {
-    const { getByText } = within(await screen.getByTestId("post-author"));
-    expect(getByText(post.author.name)).toBeInTheDocument();
-  }
-
-  {
     const { getByText } = within(await screen.getByTestId("post-content"));
     expect(getByText(post.content)).toBeInTheDocument();
   }
@@ -130,7 +125,7 @@ test("Post renders markdown", async () => {
   const h1 = container.querySelector("h1");
   expect(h1.textContent).toBe("Heading");
 
-  const a = container.querySelectorAll("a")[1];
+  const a = container.querySelectorAll("a")[0];
   expect(a.textContent).toBe("a link");
   expect(a.getAttribute("href")).toBe("/path/to/something");
 });

--- a/frontend/src/store/title.js
+++ b/frontend/src/store/title.js
@@ -1,11 +1,22 @@
 import config from "../config.json";
 
-export const titleReducer = (state = config.appTitle, action) => {
+const defaultState = {
+  page: config.appTitle,
+  author: undefined,
+};
+
+export const titleReducer = (state = defaultState, action) => {
   switch (action.type) {
     case "DEFAULT_TITLE":
-      return config.appTitle;
+      return Object.assign({}, state, {
+        page: config.appTitle,
+        author: undefined,
+      });
     case "SET_TITLE":
-      return action.title;
+      return Object.assign({}, state, {
+        page: action.title,
+        author: action.author,
+      });
     default:
       return state;
   }


### PR DESCRIPTION
Redux titleReducer changes:
- Supports `author` key

Banner content changes:
- Display author of set article

Banner style changes:
- Gradient overlay which darkens the center for more text visibility
- Full page width

Signed-off-by: Kevin Morris <kevr@0cost.org>